### PR TITLE
PR: revert prev. UI of specialAa & fix annotations bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ Moreover, please do not hesitate to `open an issue via Github` if you have any s
 
 
 # :hash: Citing the *MSABrowser*
-Upcoming 
+
+Torun, F. M., Bilgin, H. I., & Kaplan, O. I. (2021). MSABrowser: dynamic and fast visualization of sequence alignments, variations, and annotations. doi:[10.1101/2021.04.05.426321](https://www.biorxiv.org/content/10.1101/2021.04.05.426321v1) 
+

--- a/css/style.css
+++ b/css/style.css
@@ -299,15 +299,13 @@
 }
 
 
-/* Specific Amino acids for ClinVar */
+/* Specific Amino acids for alterations */
 
 .specialAa {
     cursor: pointer !important;
-    border-radius: 50%;
-    bottom: 1px;
-    line-height: 1.4 !important;
-    box-sizing: border-box;
-    border: 2px solid #fff;
+    border-radius: 40%;
+    border-color: transparent !important;
+    box-shadow: 0 0 7px #000;
 }
 
 .highlighter-container {

--- a/examples/NIPBL.html
+++ b/examples/NIPBL.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>MSABrowser|NIPBL Example</title>
-    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//css/style.css" media="screen" />
+    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1//css/style.css" media="screen" />
     <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js" type="text/javascript"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//javascript/msabrowser.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1/javascript/msabrowser.js"></script>
 </head>
 
 <body>

--- a/examples/SarsCov2.html
+++ b/examples/SarsCov2.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>MSABrowser | SARS-CoV-2 Example</title>
-    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//css/style.css" media="screen" />
+    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1//css/style.css" media="screen" />
     <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js" type="text/javascript"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//javascript/msabrowser.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1//javascript/msabrowser.js"></script>
 </head>
 
 <body>

--- a/examples/SpikeProteins.html
+++ b/examples/SpikeProteins.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>MSABrowser | Spike Proteins Example</title>
-    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//css/style.css" media="screen" />
+    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1//css/style.css" media="screen" />
     <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js" type="text/javascript"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//javascript/msabrowser.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1//javascript/msabrowser.js"></script>
 </head>
 
 <body>

--- a/examples/TUBA1A.html
+++ b/examples/TUBA1A.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>MSABrowser | TUBA1A Example</title>
-    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//css/style.css" media="screen" />
+    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1//css/style.css" media="screen" />
     <script src="https://html2canvas.hertzen.com/dist/html2canvas.min.js" type="text/javascript"></script>
     <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.0//javascript/msabrowser.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/msabrowser/msabrowser@v1.1//javascript/msabrowser.js"></script>
 </head>
 
 <body>

--- a/javascript/msabrowser.js
+++ b/javascript/msabrowser.js
@@ -522,55 +522,61 @@
 
     }
 
+    MSABrowser.prototype.renderAnnotationData = function(annotationData){
+        var name = annotationData["annotation_id"];
+        var link = annotationData["annotation_external_link"];
+        var startPoint = annotationData["annotation_start_point"];
+        var endPoint = annotationData["annotation_end_point"];
+        var repeatCount = Math.max(1, Math.round((endPoint - startPoint) * 20 / 800));
+        
+        var annotationMessage = `<p style="width: 800px">${name} (${startPoint} - ${endPoint})</p>`.repeat(repeatCount);
+
+        var annotationHtml = `
+        <a href="${link}" target="_blank">
+            <div class="annotation" data-start-point="${startPoint}" data-end-point="${endPoint}">
+                <div class="annotation_start_point">${startPoint}</div>
+                ${annotationMessage}
+                <div class="annotation_end_point">${endPoint}</div>
+            </div>
+        </a>
+        `;
+
+        return annotationHtml;
+    }
+
+    MSABrowser.prototype.addAnnotationContainer = function(geneName){
+        ids = this.ids;
+        var annotationContainerTemplate = `<section class="sequence-length"></section>`;
+        $('#' + ids.annotationSequence).append(annotationContainerTemplate);
+
+        var annotationContainer = $('#' + ids.annotationSequence).find('.sequence-length:last')[0];
+        $('#' + ids.speciesNames).before(`<div class="gene-name">`+geneName+`</div>`);
+        return annotationContainer;
+    }
+
     MSABrowser.prototype.addAnnotations = function(annotations) {
 
         var ids = this.ids;
 
-        // Check whether annotations are provided
-        if (annotations.length > 0) {
-            for (var annotation of annotations) {
-                if (this.annotations[annotation.source]) {
-                    continue;
-                }
-                this.annotations[annotation.source] = annotations.data;
-    
-                var annotationContainerTemplate = `<section class="sequence-length"></section>`;
-                $('#' + ids.annotationSequence).append(annotationContainerTemplate);
-    
-                var annotationContainer = $('#' + ids.annotationSequence).find('.sequence-length:last')[0];
-                $('#' + ids.speciesNames).before(`<div class="gene-name">${annotation.source}</div>`);
-    
-                for (var key in annotation.data) {
-                    var name = annotation.data[key]["annotation_id"];
-                    var link = annotation.data[key]["annotation_external_link"];
-                    var startPoint = annotation.data[key]["annotation_start_point"];
-                    var endPoint = annotation.data[key]["annotation_end_point"];
-                    var repeatCount = Math.max(1, Math.round((endPoint - startPoint) * 20 / 800));
-                    
-                    var annotationMessage = `<p style="width: 800px">${name} (${startPoint} - ${endPoint})</p>`.repeat(repeatCount);
-    
-                    var annotationHtml = `
-                    <a href="${link}" target="_blank">
-                        <div class="annotation" data-start-point="${startPoint}" data-end-point="${endPoint}">
-                            <div class="annotation_start_point">${startPoint}</div>
-                            ${annotationMessage}
-                            <div class="annotation_end_point">${endPoint}</div>
-                        </div>
-                    </a>
-                    `;
-    
-                    $(annotationContainer).append(annotationHtml);
-                };
-            }
+        if (annotations == null || annotations.length == 0) {
+            annotations = [{
+                source: 'MSA Browser'
+            }];
         }
 
-        // In case annotations are NOT provided
-        else {
-            var annotationContainerTemplate = `<section class="sequence-length"></section>`;
-            $('#' + ids.annotationSequence).append(annotationContainerTemplate);
+        for (var annotation of annotations) {
+            if (this.annotations[annotation.source]) {
+                continue;
+            }
+            this.annotations[annotation.source] = annotations.data;
 
-            var annotationContainer = $('#' + ids.annotationSequence).find('.sequence-length:last')[0];
-            $('#' + ids.speciesNames).before(`<div class="gene-name">MSABrowser</div>`);
+            var annotationContainer = this.addAnnotationContainer(annotation.source);
+
+            for (var key in annotation.data) {
+                annotationHtml = this.renderAnnotationData(annotation.data[key])
+
+                $(annotationContainer).append(annotationHtml);
+            };
         }
         
     }

--- a/javascript/msabrowser.js
+++ b/javascript/msabrowser.js
@@ -39,7 +39,6 @@
             return link;
         }
 
-
         this.loadSeq = function(fasta) {
             let firstStartPointer, endPointer, currentStartPointer = -1;
 
@@ -527,42 +526,53 @@
 
         var ids = this.ids;
 
-        for (var annotation of annotations) {
-            if (this.annotations[annotation.source]) {
-                continue;
+        // Check whether annotations are provided
+        if (annotations.length > 0) {
+            for (var annotation of annotations) {
+                if (this.annotations[annotation.source]) {
+                    continue;
+                }
+                this.annotations[annotation.source] = annotations.data;
+    
+                var annotationContainerTemplate = `<section class="sequence-length"></section>`;
+                $('#' + ids.annotationSequence).append(annotationContainerTemplate);
+    
+                var annotationContainer = $('#' + ids.annotationSequence).find('.sequence-length:last')[0];
+                $('#' + ids.speciesNames).before(`<div class="gene-name">${annotation.source}</div>`);
+    
+                for (var key in annotation.data) {
+                    var name = annotation.data[key]["annotation_id"];
+                    var link = annotation.data[key]["annotation_external_link"];
+                    var startPoint = annotation.data[key]["annotation_start_point"];
+                    var endPoint = annotation.data[key]["annotation_end_point"];
+                    var repeatCount = Math.max(1, Math.round((endPoint - startPoint) * 20 / 800));
+                    
+                    var annotationMessage = `<p style="width: 800px">${name} (${startPoint} - ${endPoint})</p>`.repeat(repeatCount);
+    
+                    var annotationHtml = `
+                    <a href="${link}" target="_blank">
+                        <div class="annotation" data-start-point="${startPoint}" data-end-point="${endPoint}">
+                            <div class="annotation_start_point">${startPoint}</div>
+                            ${annotationMessage}
+                            <div class="annotation_end_point">${endPoint}</div>
+                        </div>
+                    </a>
+                    `;
+    
+                    $(annotationContainer).append(annotationHtml);
+                };
             }
-            this.annotations[annotation.source] = annotations.data;
+        }
 
+        // In case annotations are NOT provided
+        else {
             var annotationContainerTemplate = `<section class="sequence-length"></section>`;
             $('#' + ids.annotationSequence).append(annotationContainerTemplate);
 
-
             var annotationContainer = $('#' + ids.annotationSequence).find('.sequence-length:last')[0];
-            $('#' + ids.speciesNames).before(`<div class="gene-name">${annotation.source}</div>`);
-
-            for (var key in annotation.data) {
-                var name = annotation.data[key]["annotation_id"];
-                var link = annotation.data[key]["annotation_external_link"];
-                var startPoint = annotation.data[key]["annotation_start_point"];
-                var endPoint = annotation.data[key]["annotation_end_point"];
-                var repeatCount = Math.max(1, Math.round((endPoint - startPoint) * 20 / 800));
-                
-                var annotationMessage = `<p style="width: 800px">${name} (${startPoint} - ${endPoint})</p>`.repeat(repeatCount);
-
-
-                var annotationHtml = `
-                <a href="${link}" target="_blank">
-                    <div class="annotation" data-start-point="${startPoint}" data-end-point="${endPoint}">
-                        <div class="annotation_start_point">${startPoint}</div>
-                        ${annotationMessage}
-                        <div class="annotation_end_point">${endPoint}</div>
-                    </div>
-                </a>
-                `;
-
-                $(annotationContainer).append(annotationHtml);
-            };
+            $('#' + ids.speciesNames).before(`<div class="gene-name">MSABrowser</div>`);
         }
+        
     }
 
     MSABrowser.prototype.addAlteration = function({


### PR DESCRIPTION
Dear Halil,

In this PR, the following issues are addressed:

- The `specialAa ` appearance has been reverted back to its previous version (version 1), which we provide via the CDN.

- The problem on MSA displaying without `annotations` variable, which is discussed here https://github.com/thekaplanlab/msabrowser/issues/3,  has been fixed.

> Note that for the second issue, the quick solution is to define `annotations` as `[{}]` as a blank. However, as for undefined case, a new if-else is implemented.

Can you check and merge & release new version followed by updating our website for CDN links?

Best,
Furkan